### PR TITLE
Fix role to work for Debian hosts

### DIFF
--- a/ansible/influxdb-meta/.gitignore
+++ b/ansible/influxdb-meta/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+*.retry

--- a/ansible/influxdb-meta/Vagrantfile
+++ b/ansible/influxdb-meta/Vagrantfile
@@ -2,41 +2,49 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/trusty64"
-  # config.vm.box = "relativkreativ/centos-7-minimal"
-  # config.vm.box = "puppetlabs/centos-6.6-64-nocm"
-  # config.vm.box = "debian/jessie64"
+  config.vm.box = ENV["VAGRANT_VM_BOX"] ||  "ubuntu/trusty64"
 
-  BOX_COUNT = 1
+  BOX_COUNT      = ENV["VAGRANT_BOX_COUNT"] ? ENV["VAGRANT_BOX_COUNT"].to_i : 3
+  MEMORY         = ENV["VAGRANT_MEMORY"] || 256
+  CPUS           = ENV["VAGRANT_CPUS"] || 1
+  HTTP_BIND_PORT = 8091
+
+  leader = ""
+  members = Array.new
+
   (1..BOX_COUNT).each do |machine_id|
-    config.vm.define "influx#{machine_id}" do |machine|
-      machine.vm.hostname = "influx#{machine_id}"
+    primary      = machine_id == 1 ? true : false
+    host_postfix = "%03d" % machine_id
+    hostname     = "metanode-#{host_postfix}"
+    leader       = hostname if machine_id == 1
+
+    members << hostname
+
+    config.vm.define hostname, primary: primary do |machine|
+      machine.vm.hostname = hostname
       machine.vm.network "private_network", type: "dhcp"
-      # machine.vm.network "public_network"
-      # machine.vm.network "public_network", :bridge => 'en0: Wi-Fi (AirPort)'
-
+      machine.vm.network "forwarded_port", guest: HTTP_BIND_PORT, host: HTTP_BIND_PORT if primary
       machine.vm.provider "virtualbox" do |v|
-        v.memory = 1024
-        v.cpus = 1
+        v.memory = MEMORY
+        v.cpus   = CPUS
       end
 
-      if machine_id == BOX_COUNT
-        machine.vm.provision "ansible" do |ansible|
-          ansible.verbose = 'v'
-          ansible.limit = 'all'
-          if BOX_COUNT > 1
-            ansible.playbook = "cluster-test.yml"
-          else
-            ansible.playbook = "test.yml"
-          end
-          ansible.sudo = true
-          ansible.host_key_checking = false
-          ansible.extra_vars = {
-            is_vagrant: true,
-          }
-        end
-      end
+      machine.vm.provision "ansible" do |ansible|
+        ansible.verbose           = 'vv'
+        ansible.limit             = 'all'
+        ansible.playbook          = "tests/vagrant.yml"
+        ansible.sudo              = true
+        ansible.raw_arguments     = ENV["ANSIBLE_RAW_ARGS"] || nil
+        ansible.host_key_checking = false
+        ansible.groups            = {"meta-nodes" => members}
 
+        ansible.extra_vars = {
+          influx_enterprise_license_key: ENV['INFLUXDB_ENTERPRISE_LICENSE_KEY'],
+          influxdb_meta_cluster_leader: leader,
+          influxdb_meta_cluster_members: members,
+          influxdb_meta_http_bind_address_port: 8091
+        }
+      end if machine_id == BOX_COUNT # Run Ansible, only once the final machine is configured
     end
   end
 end

--- a/ansible/influxdb-meta/ansible.cfg
+++ b/ansible/influxdb-meta/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ./..

--- a/ansible/influxdb-meta/defaults/main.yml
+++ b/ansible/influxdb-meta/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
-
 influx_enterprise_license_key:
-influxdb_meta_install_url: https://dl.influxdata.com/enterprise/releases/influxdb-meta-1.1.1_c1.1.1.x86_64.rpm
 
 influxdb_meta_configuration_dir: /etc/influxdb
 
@@ -32,3 +30,9 @@ influxdb_meta_raft_promotion_enabled: true
 influxdb_meta_logging_enabled: true
 influxdb_meta_pprof_enabled: false
 influxdb_meta_lease_duration: 1m0s
+
+influxdb_meta_package_base_url: "https://s3.amazonaws.com/dl.influxdata.com"
+
+influxdb_meta_cluster_auto_join: true # Attempt to add all members to the cluster automatically
+influxdb_meta_cluster_leader: # The IP of the meta-node cluster leader
+influxdb_meta_cluster_members: # A list of cluster members

--- a/ansible/influxdb-meta/full-stack.yml
+++ b/ansible/influxdb-meta/full-stack.yml
@@ -1,3 +1,4 @@
+---
 - hosts: all
   roles:
     - role: influxdb-data
@@ -5,4 +6,3 @@
 - hosts: all
   roles:
     - role: influxdb-meta
-

--- a/ansible/influxdb-meta/handlers/main.yml
+++ b/ansible/influxdb-meta/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart influxdb-meta service
-  service: 
+  service:
     name: influxdb-meta
     state: restarted
 

--- a/ansible/influxdb-meta/tasks/configure.yml
+++ b/ansible/influxdb-meta/tasks/configure.yml
@@ -5,8 +5,8 @@
     state: directory
 
 - name: Set templatized influxdb-meta configuration
-  template: 
-    src: influxdb-meta.conf.j2 
+  template:
+    src: influxdb-meta.conf.j2
     dest: "{{ influxdb_meta_configuration_dir }}/influxdb-meta.conf"
     force: yes
     backup: yes
@@ -14,18 +14,3 @@
     group: influxdb
     mode: 0744
   when: influxdb_meta_template_configuration
-
-- name: Overwrite hosts file
-  template:
-    src: etc/hosts.j2
-    dest: /etc/hosts
-    owner: root
-    group: root
-    mode: 0644
-  when: is_vagrant or influxdb_meta_overwrite_hosts
-  
-- name: Stop firewalld [local testing only]
-  service:
-      name: firewalld
-      state: stopped
-  when: is_vagrant and ansible_distribution == 'CentOS'

--- a/ansible/influxdb-meta/tasks/install-debian.yml
+++ b/ansible/influxdb-meta/tasks/install-debian.yml
@@ -1,20 +1,5 @@
 ---
 - name: Install any necessary dependencies [Debian/Ubuntu]
   apt:
-    name: "{{ item }}"
-    state: present
-    update_cache: yes
-    cache_valid_time: 3600
-  with_items:
-    - curl
-    - python-httplib2
-
-- name: Download influxdb-meta package via URL [Debian/Ubuntu]
-  command: curl -o /tmp/influxdb-meta-ansible-download.deb {{ influxdb_meta_install_url }}
-  when: influxdb_meta_install_url is defined and influxdb_meta_install_url != None
-
-- name: Install downloaded influxdb-meta package [Debian/Ubuntu]
-  apt:
-    deb: /tmp/influxdb-meta-ansible-download.deb
-    state: present
-  when: influxdb_meta_install_url is defined and influxdb_meta_install_url != None
+      deb: "{{ influxdb_meta_install_url }}"
+      state: present

--- a/ansible/influxdb-meta/tasks/install.yml
+++ b/ansible/influxdb-meta/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
-- include: install-redhat.yml
-  when: ansible_os_family == "RedHat"
+- name: "Loading vars for {{ ansible_os_family }}"
+  include_vars: "{{ ansible_os_family | lower }}.yml"
 
-- include: install-debian.yml
-  when: ansible_os_family == "Debian"
+- name: "Installing for {{ ansible_os_family }}"
+  include: "install-{{ ansible_os_family | lower }}.yml"

--- a/ansible/influxdb-meta/tasks/main.yml
+++ b/ansible/influxdb-meta/tasks/main.yml
@@ -1,43 +1,9 @@
 ---
 - include: install.yml
-  tags: [influxdb-meta, install]
+  tags: [influxdb-meta, influxdb-meta-install]
 
 - include: configure.yml
-  tags: [influxdb-meta, configure]
+  tags: [influxdb-meta, influxdb-meta-configure]
 
-- name: Start the influxdb-meta service
-  service:
-    name: influxdb-meta
-    state: restarted
-    enabled: yes
-  register: influxdb_meta_started
-  when: influxdb_meta_start_service
-
-- name: Wait for influxdb-meta to come up
-  wait_for:
-    host: "{{ influxdb_meta_http_bind_address_hostname | default(\"localhost\", true) }}"
-    port: "{{ influxdb_meta_http_bind_address_port }}"
-    delay: 1
-    timeout: 5
-  when: influxdb_meta_started.changed and influxdb_meta_start_service
-  ignore_errors: yes
-  register: influxdb_meta_start_attempt
-
-- name: Assert status of influxdb-meta service
-  assert:
-    that:
-      - "influxdb_start_attempt == 0"
-  when: influxdb_meta_started.changed and influxdb_meta_start_service and influxdb_meta_start_attempt.failed is defined and influxdb_meta_start_attempt.failed == True
-
-# FIXME: Don't hard-code port 8091
-- name: Capture current cluster status
-  uri:
-    url: http://localhost:8091/show-cluster
-  register: influxdb_meta_show_cluster
-
-# FIXME: Don't hard-code port 8091
-- name: Add meta nodes to cluster (run from first meta node)
-  command: influxd-ctl add-meta {{ item }}:8091
-  when: "'{{ item }}:8091' not in influxdb_meta_show_cluster['json']['meta']|map(attribute='addr')|list"
-  with_items: "{{ groups.meta }}"
-  delegate_to: "{{ groups.meta[0] }}"
+- include: service.yml
+  tags: [influxdb-meta, influxdb-meta-service]

--- a/ansible/influxdb-meta/tasks/service.yml
+++ b/ansible/influxdb-meta/tasks/service.yml
@@ -1,0 +1,38 @@
+- name: Start the influxdb-meta service
+  service:
+    name: influxdb-meta
+    state: restarted
+    enabled: yes
+  register: influxdb_meta_started
+  when: influxdb_meta_start_service
+
+- name: Wait for influxdb-meta to come up
+  wait_for:
+    host: "{{ influxdb_meta_http_bind_address_hostname | default('localhost', true) }}"
+    port: "{{ influxdb_meta_http_bind_address_port }}"
+    delay: 2
+    timeout: 3
+  when: influxdb_meta_started.changed and influxdb_meta_start_service
+  ignore_errors: yes
+  register: influxdb_meta_start_attempt
+
+- name: Assert status of influxdb-meta service
+  assert:
+    that:
+      - "influxdb_start_attempt == 0"
+  when:
+    - influxdb_meta_started.changed
+    - influxdb_meta_start_service
+    - influxdb_meta_start_attempt.failed is defined
+    - influxdb_meta_start_attempt.failed == True
+
+- name: Add meta nodes to cluster (run from first meta node)
+  command: "influxd-ctl add-meta {{ item }}:{{influxdb_meta_http_bind_address_port }}"
+  with_items: "{{ influxdb_meta_cluster_members }}"
+  delegate_to: "{{ influxdb_meta_cluster_leader }}"
+  when:
+    - influxdb_meta_cluster_auto_join == True
+    - influxdb_meta_cluster_leader == ansible_hostname
+    - influxdb_meta_cluster_leader is defined
+    - influxdb_meta_cluster_members is defined
+  tags: cluster

--- a/ansible/influxdb-meta/test.yml
+++ b/ansible/influxdb-meta/test.yml
@@ -1,8 +1,0 @@
-- hosts: all
-  vars_files:
-    - defaults/main.yml
-    - vars/main.yml
-  tasks:
-    - include: tasks/main.yml
-  handlers:
-    - include: handlers/main.yml

--- a/ansible/influxdb-meta/tests/cluster.yml
+++ b/ansible/influxdb-meta/tests/cluster.yml
@@ -1,0 +1,36 @@
+---
+# These tests need to be run against a cluster with at least 3 meta-nodes in the cluster
+- hosts: localhost
+  tasks:
+    - name: Test erroneous endpoint
+      uri:
+          url: http://localhost:8091/ding
+          status_code: 400
+          return_content: yes
+      register: body
+
+    - name: Test erroneous response body
+      fail:
+      when: "'error parsing index' not in body.content"
+
+    - name: Test ping resrouce
+      uri:
+          url: http://localhost:8091/ping
+          status_code: 200
+          return_content: yes
+      register: body
+
+    - name: Test ping response
+      fail:
+      when: "body.json.addr != 'metanode-001:8089'"
+
+    - name: Test ping resrouce
+      uri:
+          url: http://localhost:8091/status
+          status_code: 200
+          return_content: yes
+      register: body
+
+    - name: Test if there are enough peers in the cluster
+      fail:
+      when: body.json.peers|length|int < 3

--- a/ansible/influxdb-meta/tests/vagrant.yml
+++ b/ansible/influxdb-meta/tests/vagrant.yml
@@ -1,0 +1,13 @@
+---
+- hosts: all
+  pre_tasks:
+    - name: "Populate hosts file"
+      lineinfile:
+        dest: /etc/hosts
+        regexp: '.*{{ item }}$'
+        line: "{{ hostvars[item].facter_ipaddress_eth1 }}  {{item}}"
+        state: present
+      when: groups['meta-nodes'] is defined
+      with_items: "{{ groups['meta-nodes'] }}"
+  roles:
+      - influxdb-meta

--- a/ansible/influxdb-meta/vars/debian.yml
+++ b/ansible/influxdb-meta/vars/debian.yml
@@ -1,0 +1,2 @@
+---
+influxdb_meta_install_url: "{{ influxdb_meta_package_base_url }}/enterprise/releases/influxdb-meta_1.1.1-c1.1.1_amd64.deb"

--- a/ansible/influxdb-meta/vars/main.yml
+++ b/ansible/influxdb-meta/vars/main.yml
@@ -1,14 +1,6 @@
 ---
-
-# Whether or not the playbook is run locally (changes clustering and testing logic slightly)
-# This should only be set in the Vagrantfile and not modified elsewhere
-is_vagrant: no
-
 # If yes, service will be started. Will not be started if set to no.
 influxdb_meta_start_service: yes
 
 # If yes, will overwrite the packaged configuration with an Asnible/jinja2 template
 influxdb_meta_template_configuration: yes
-
-# Yes, will overwrite the /etc/hosts file with the hostnames from the inventory
-influxdb_meta_overwrite_hosts: no

--- a/ansible/influxdb-meta/vars/redhat.yml
+++ b/ansible/influxdb-meta/vars/redhat.yml
@@ -1,0 +1,2 @@
+---
+influxdb_meta_install_url: "{{ influxdb_meta_package_base_url }}/enterprise/releases/influxdb-meta-1.1.1_c1.1.1.x86_64.rpm"


### PR DESCRIPTION
Mosttly just a tidy up and fixes some issues which are outlined below.

* Split role to use "OS family" specific vars and tasks.
* Allow for setting the license keys for vagrant via ENV variable.
* Rename the Playbooks to be a little more explicit about their purpose.
* Tidy up Vagrant file
* Don't  manipulate host file on machines, use dedicated module for this.
* Firewalls are disabled on vagrant boxes by default, remove this.
* Add ignore.
* Users explicitly configure cluster leader and members.
* Add ansible.cfg so we can test the role via `role` declaration
* Add tests and CirclCI build