### PR TITLE
Add ability to specify license file as a yaml object

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ influx_meta_cluster_leader: # The IP of the meta-node cluster leader
 
 # Enterprise settings
 influx_enterprise_license_key:
+influx_enterprise_license:
 
 # influxdb-meta.conf.j2 template options
 influx_meta_reporting_disabled: false
@@ -19,7 +20,7 @@ influx_meta_bind_address:
 influx_meta_bind_port: 8089
 influx_meta_registration_enabled: false
 influx_meta_registration_server_url:
-influx_meta_license_path:
+influx_meta_license_path: "{{ influx_configuration_dir }}/{{ influx_license_filenames[influx_node_type] }}"
 influx_meta_dir: /var/lib/influxdb/meta
 influx_meta_http_bind_address:
 influx_meta_http_bind_port: 8091
@@ -46,7 +47,7 @@ influx_data_disable_reporting: false
 influx_data_meta_tls_enabled: false
 influx_data_registration_enabled: false
 influx_data_registration_server_url:
-influx_data_license_path:
+influx_data_license_path: "{{ influx_configuration_dir }}/{{ influx_license_filenames[influx_node_type] }}"
 influx_data_enabled: true
 influx_data_dir: /var/lib/influxdb/data
 influx_data_max_wal_size: 104857600

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,10 +46,21 @@
     enabled: 'yes'
   tags: ['influx', 'service', "{{ influx_node_type }}"]
 
+- name: "{{ influx_node_type }} : Get list of nodes in the cluster"
+  command: "influxd-ctl show"
+  delegate_to: "{{ influx_meta_cluster_leader }}"
+  when:
+    - influx_cluster_auto_join
+    - influx_meta_cluster_leader is defined
+  register: influx_cluster_state
+  changed_when: false
+  tags: ['influx', 'cluster', "{{ influx_node_type }}"]
+
 - name: "{{ influx_node_type }} : Add node to cluster"
   command: "influxd-ctl add-{{ influx_node_type }} {{ ansible_hostname }}:{{ (influx_node_type == 'meta') | ternary(influx_meta_http_bind_port, influx_data_bind_port) }}"
   delegate_to: "{{ influx_meta_cluster_leader }}"
   when:
     - influx_cluster_auto_join
     - influx_meta_cluster_leader is defined
+    - ansible_hostname not in influx_cluster_state.stdout
   tags: ['influx', 'cluster', "{{ influx_node_type }}"]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,19 @@
   when: influx_manage_config
   tags: ['influx', 'config', "{{ influx_node_type }}"]
 
+- name: "{{ influx_node_type }} : Build and install license file"
+  copy:
+    dest: "{{ influx_configuration_dir }}/{{ influx_license_filenames[influx_node_type] }}"
+    content: "{{ influx_enterprise_license}}"
+    force: 'yes'
+    backup: 'yes'
+    owner: 'influxdb'
+    group: 'influxdb'
+    mode: 0744
+  notify: "restart influxdb-{{ influx_node_type }}"
+  when: influx_enterprise_license is defined
+  tags: ['influx', 'config', "{{ influx_node_type }}"]
+
 - name: "{{ influx_node_type }} : Start and enable the service"
   service:
     name: "{{ influx_svc_names[influx_node_type] }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,4 @@
 # These vars have the highest precedence, should rarely be changed.
 influx_svc_names: { 'data': 'influxdb', 'meta': 'influxdb-meta' }
 influx_config_filenames: { 'data': 'influxdb.conf', 'meta': 'influxdb-meta.conf' }
+influx_license_filenames: { 'data': 'license.json', 'meta': 'license-meta.json' }


### PR DESCRIPTION
This PR adds functionality to support passing a license file contents in a form of a json object. Please let me know what you think:
```yaml
influx_enterprise_license:
  license:
     key: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx"
     state: active
     expires_at: "2020-01-01T00:00:00Z"
     valid: true
     entitlements:
      influx_machines: "1"
      influx_cores: "1"
      web_users: "5"
     plan:
      name: "Foobar Inc 1x1 Cluster"
     product:
      name: "InfluxData Enterprise"
      family: "1.x"
    signature: "XxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXX.xxXxXXXxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXxxxxXXXxxxXxXxxxxxXxxxXxXxXXXxxxxXxxXxXx"
    signature_expires_at: "2020-01-01T00:00:00Z"
```