### PR TITLE
Add ability to provide license file via yaml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,8 @@
 # Role Settings
 influx_node_types: ["meta", "data"]
 influx_node_type: "meta" # By default, install node as a meta-node
-influx_pkg_base_url: "https://s3.amazonaws.com/dl.influxdata.com/enterprise/releases"
-influx_version: "1.2.4-c1.2.5" # The version of the package to install
+influx_pkg_base_url: "https://dl.influxdata.com/enterprise/releases"
+influx_version: "1.3.2-c1.3.2" # The version of the package to install
 influx_configuration_dir: "/etc/influxdb" # The base directory of the config
 influx_manage_config: true # Build and install config from templates
 influx_cluster_auto_join: true # Attempt to add members to the cluster automatically

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ influx_meta_cluster_leader: # The IP of the meta-node cluster leader
 
 # Enterprise settings
 influx_enterprise_license_key:
+influx_enterprise_license:
 
 # influxdb-meta.conf.j2 template options
 influx_meta_reporting_disabled: false
@@ -18,7 +19,7 @@ influx_meta_bind_address:
 influx_meta_bind_port: 8089
 influx_meta_registration_enabled: false
 influx_meta_registration_server_url:
-influx_meta_license_path:
+influx_meta_license_path: "{{ influx_configuration_dir }}/{{ influx_license_filenames[influx_node_type] }}"
 influx_meta_dir: /var/lib/influxdb/meta
 influx_meta_http_bind_address:
 influx_meta_http_bind_port: 8091
@@ -45,7 +46,7 @@ influx_data_disable_reporting: false
 influx_data_meta_tls_enabled: false
 influx_data_registration_enabled: false
 influx_data_registration_server_url:
-influx_data_license_path:
+influx_data_license_path: "{{ influx_configuration_dir }}/{{ influx_license_filenames[influx_node_type] }}"
 influx_data_enabled: true
 influx_data_dir: /var/lib/influxdb/data
 influx_data_max_wal_size: 104857600

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,19 @@
   when: influx_manage_config
   tags: ['influx', 'config', "{{ influx_node_type }}"]
 
+- name: "{{ influx_node_type }} : Build and install license file"
+  copy:
+    dest: "{{ influx_configuration_dir }}/{{ influx_license_filenames[influx_node_type] }}"
+    content: "{{ influx_enterprise_license}}"
+    force: 'yes'
+    backup: 'yes'
+    owner: 'influxdb'
+    group: 'influxdb'
+    mode: 0744
+  notify: "restart influxdb-{{ influx_node_type }}"
+  when: influx_enterprise_license is defined
+  tags: ['influx', 'config', "{{ influx_node_type }}"]
+
 - name: "{{ influx_node_type }} : Start and enable the service"
   service:
     name: "{{ influx_svc_names[influx_node_type] }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,4 @@
 # These vars have the highest precedence, should rarely be changed.
 influx_svc_names: { 'data': 'influxdb', 'meta': 'influxdb-meta' }
 influx_config_filenames: { 'data': 'influxdb.conf', 'meta': 'influxdb-meta.conf' }
+influx_license_filenames: { 'data': 'license.json', 'meta': 'license-meta.json' }


### PR DESCRIPTION
This PR is adding ability to specify your offline license file as yaml data structure right in role parameters.

I followed the pattern of separate config files for different node type, so there are 2 different license file names for data and meta nodes. 