### PR TITLE
Higher default cache size, index version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,7 +103,7 @@ influx_data_cq_enabled: true
 influx_data_cq_run_interval: 1s
 influx_data_hh_enabled: true
 influx_data_hh_dir: /var/lib/influxdb/hh
-influx_data_hh_max_size: 1073741824
+influx_data_hh_max_size: 10737418240
 influx_data_hh_max_age: 168h0m0s
 influx_data_hh_retry_rate_limit: 0
 influx_data_hh_retry_interval: 1s

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,7 +64,7 @@ influx_data_wal_max_series_size: 1048576
 influx_data_wal_flush_cold_interval: 5s
 influx_data_wal_partition_size_threshold: 52428800
 influx_data_query_log_enabled: true
-influx_data_cache_max_memory_size: 524288000
+influx_data_cache_max_memory_size: 1073741824
 influx_data_cache_snapshot_memory_size: 26214400
 influx_data_cache_snapshot_write_cold_duration: 1h0m0s
 influx_data_compact_full_write_cold_duration: 24h0m0s

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 influx_node_types: ["meta", "data"]
 influx_node_type: "meta" # By default, install node as a meta-node
 influx_pkg_base_url: "https://dl.influxdata.com/enterprise/releases"
-influx_version: "1.3.7-c1.3.7" # The version of the package to install
+influx_version: "1.6.2-c1.6.2" # The version of the package to install
 influx_configuration_dir: "/etc/influxdb" # The base directory of the config
 influx_manage_config: true # Build and install config from templates
 influx_cluster_auto_join: true # Attempt to add members to the cluster automatically

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,7 @@ influx_meta_lease_duration: 1m0s
 
 # influxdb-data.conf.j2 parameters
 influx_data_bind_address:
+influx_data_index_version: "inmem"
 influx_data_bind_port: 8088
 influx_data_configuration_dir: /etc/influxdb
 influx_data_disable_reporting: false

--- a/templates/influxdb-data.conf.j2
+++ b/templates/influxdb-data.conf.j2
@@ -25,6 +25,7 @@ bind-address = "{{ influx_data_bind_address }}:{{ influx_data_bind_port|mandator
 [data]
   enabled = {{ influx_data_enabled|lower|mandatory }}
   dir = "{{ influx_data_dir|mandatory }}"
+  index-version = "{{ influx_data_index_version }}"
   max-wal-size = {{ influx_data_max_wal_size|mandatory }}
   wal-flush-interval = "{{ influx_data_wal_flush_interval|mandatory }}"
   wal-partition-flush-delay = "{{ influx_data_wal_partition_flush_delay|mandatory }}"


### PR DESCRIPTION
- Added possibility to specify index version
- Cache memory size 1G as in the default config of data node
- HHQ max size 10G as in the default config of data node
- Default version to the latest: 1.6.2